### PR TITLE
ModFile size_in_bytes should be a long, not an integer

### DIFF
--- a/FluentNexus/Models/ModFile.cs
+++ b/FluentNexus/Models/ModFile.cs
@@ -49,7 +49,7 @@ namespace Pathoschild.FluentNexus.Models
 
         /// <summary>The file size in bytes, if available.</summary>
         [JsonProperty("size_in_bytes")]
-        public int? SizeInBytes { get; set; }
+        public long? SizeInBytes { get; set; }
 
         /// <summary>When the file was uploaded.</summary>
         [JsonProperty("uploaded_timestamp")]


### PR DESCRIPTION
My modding domains (mass effect) has several very large mods (>2GB). The recent addition of size_in_bytes is nice, but it breaks when getting information about a file if it is >2GB, because it's defined as an int? instead of a long?. As such, when the json is attempted to be deserialized, it throws an exception instead. This PR fixes that by changing the int datatype to long.

An example mod would be this one: https://www.nexusmods.com/masseffect3/mods/691?tab=files